### PR TITLE
correct variable naming from 'engine' to 'backend' in dataset loading…

### DIFF
--- a/example_notebooks/basic_dataset_example.ipynb
+++ b/example_notebooks/basic_dataset_example.ipynb
@@ -222,7 +222,7 @@
     "\n",
     "Datasets in the NNJA-AI archive may contain dozens or hundreds of individual variables, each representing a column of the underlying parquet dataset. These can be accessed directly using dataset.variables. Variables are grouped into 4 categories: __primary data__ (e.g. `brightness temeperature`), __secondary data__ (e.g. `standard deviation of brightness temperature`), __primary descriptors__ (e.g. `latitude`), and __secondary descriptors__ (e.g. `field of view number`). These groupings are a *subjective* assignment based on whether the data represents something about the world vs. something about the observer, and whether the data is important or not. \n",
     "\n",
-    "Depending on the engine used to load data, early subsetting by variables can significantly increase load times; of course, you can also load the data and subset columns directly."
+    "Depending on the backend used to load data, early subsetting by variables can significantly increase load times; of course, you can also load the data and subset columns directly."
    ]
   },
   {
@@ -324,11 +324,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = amsu_ds_sub.load_dataset(engine='pandas')"
+    "df = amsu_ds_sub.load_dataset(backend='pandas')"
    ]
   },
   {
@@ -370,7 +370,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -391,7 +391,7 @@
     "    time='2021-01-01 00Z',\n",
     "    variables=['LAT', 'LON', 'TMBR_00001']\n",
     ")\n",
-    "df = amsu_ds.load_dataset(engine='pandas')\n",
+    "df = amsu_ds.load_dataset(backend='pandas')\n",
     "plot_df(df, 'TMBR_00001')"
    ]
   }

--- a/src/nnja/io.py
+++ b/src/nnja/io.py
@@ -114,7 +114,12 @@ def load_parquet(
 
             return pd.concat(
                 [
-                    pd.read_parquet(uri, columns=columns, storage_options=auth_args)
+                    pd.read_parquet(
+                        uri,
+                        columns=columns,
+                        storage_options=auth_args,
+                        **backend_kwargs,
+                    )
                     for uri in parquet_uris
                 ]
             )


### PR DESCRIPTION
… functions and pass backend_kwargs to pandas in load_dataset. 

Addresses #34. 

Now 'engine' is also usable by pandas (e.g. to specify pyarrow vs fastparquet) and the expected error is raised (in this case, that "engine=pandas" is not a valid kwarg value for pandas). 