### PR TITLE
Add documentation for satellite radiance datasets and create FAQ page

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -165,3 +165,73 @@ Surface data from fixed land stations, originally received in BUFR format. This 
 #### Additional Resources
 
 - [BUFR source data on AWS](https://noaa-reanalyses-pds.s3.amazonaws.com/index.html#observations/reanalysis/adpsfc/nc000101/)
+
+
+### Himawari Advanced Himawari Imager (AHI) Clear-Sky Radiance
+
+- Sensor: `geo`
+- Source: `ahicsr`
+- Message: `NC021044`
+- Dates processed: `March 2021-August 2024`
+
+This dataset contains clear-sky radiance measurements from the Advanced Himawari Imager (AHI) instrument aboard the JMA Himawari geostationary satellites. The data is processed to include only clear-sky conditions. The primary data packet consists of brightness temperature measurements (TMBRST) for 10 channels, with channels 11 and 12 currently not populated, nor are the channel band widths (SCBW) and cloud type (CLTP) populated for all channels.
+
+#### Additional Resources
+
+- [OSCAR Instrument Detail Page](https://space.oscar.wmo.int/instruments/view/ahi)
+- [JMA Himawari Overview](https://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html)
+- [BUFR source data on AWS](https://noaa-reanalyses-pds.s3.amazonaws.com/index.html#observations/reanalysis/geo/ahicsr/)
+
+### GOES All-Sky Radiances
+
+- Sensor: `geo`
+- Source: `gsrasr`
+- Message: `NC021045`
+- Dates processed: `March 2021-August 2024`
+
+This dataset contains all-sky radiance measurements from the Advanced Baseline Imager (ABI) aboard GOES satellites. The data includes radiance measurements under all atmospheric conditions, providing comprehensive coverage of the Americas and surrounding oceanic regions. The primary data packet includes brightness temperature measurements for 10 channels under various conditions:
+- All-sky conditions (TMBRST_allsky)
+- Clear-sky conditions (TMBRST_clearsky)
+- All-cloud conditions (TMBRST_allcloud)
+
+While the dataset does have cloud-height specific measurements (TMBRST_lowcloud, TMBRST_midcloud, TMBRST_highcloud), they are currently not populated.
+#### Additional Resources
+
+- [OSCAR Instrument Detail Page](https://space.oscar.wmo.int/instruments/view/abi)
+- [GOES ABI Overview](https://www.goes-r.gov/spacesegment/abi.html)
+- [BUFR source data on AWS](https://noaa-reanalyses-pds.s3.amazonaws.com/index.html#observations/reanalysis/geo/gsrasr/)
+
+### GOES Clear-Sky Radiances
+
+- Sensor: `geo`
+- Source: `gsrcsr`
+- Message: `NC021046`
+- Dates processed: `March 2021-August 2024`
+
+This dataset contains clear-sky radiance measurements from the Advanced Baseline Imager (ABI) aboard GOES satellites. The data is specifically filtered to include only measurements taken under clear-sky conditions, making it particularly valuable for applications requiring unobstructed atmospheric measurements and radiative transfer modeling. The primary data packet consists of brightness temperature measurements (TMBRST) for 10 channels.
+
+#### Additional Resources
+
+- [OSCAR Instrument Detail Page](https://space.oscar.wmo.int/instruments/view/abi)
+- [GOES ABI Overview](https://www.goes-r.gov/spacesegment/abi.html)
+- [BUFR source data on AWS](https://noaa-reanalyses-pds.s3.amazonaws.com/index.html#observations/reanalysis/geo/gsrcsr/)
+
+### SEVIRI All-Sky Radiances
+
+- Sensor: `seviri`
+- Source: `sevasr`
+- Message: `NC021042`
+- Dates processed: `March 2022-August 2024`
+
+This dataset contains all-sky radiance measurements from the Spinning Enhanced Visible and InfraRed Imager (SEVIRI) instrument aboard Meteosat Second Generation (MSG) satellites. The data includes radiance measurements under all atmospheric conditions, providing comprehensive coverage over Europe, Africa, and surrounding regions. The primary data packet includes brightness temperature measurements for 11 channels (visible/near-IR channels 1-3 currently not populated) under various conditions:
+- All-sky conditions (TMBRST_allsky)
+- Clear-sky conditions (TMBRST_clearsky)
+- All-cloud conditions (TMBRST_allcloud)
+- Cloud-type specific conditions (high/mid/low cloud, TMBRST_highcloud, etc.)
+
+Each measurement type includes corresponding standard deviation fields (SDTB). Some cloud-type specific measurements have partial coverage.
+
+#### Additional Resources
+
+- [OSCAR Instrument Detail Page](https://space.oscar.wmo.int/instruments/view/seviri)
+- [BUFR source data on AWS](https://noaa-reanalyses-pds.s3.amazonaws.com/index.html#observations/reanalysis/seviri/sevasr/)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,83 @@
+# Frequently Asked Questions
+
+- [What is the status of this archive?](#what-is-the-status-of-this-archive)
+- [What datasets do you have?](#what-datasets-do-you-have)
+- [What format is the data in and where is it stored?](#what-format-is-the-data-in-and-where-is-it-stored)
+- [Why is are some columns still a structured field?](#why-is-are-some-columns-still-a-structured-field)
+- [Why is this entire column missing data?](#why-is-this-entire-column-missing-data)
+- [Why didn't you use zarr instead of parquet?](#why-didn-t-you-use-zarr-instead-of-parquet)
+- [There are too many columns! How do I filter them?](#there-are-too-many-columns-how-do-i-filter-them)
+- [Will you keep the datasets current with the most recent data?](#will-you-keep-the-datasets-current-with-the-most-recent-data)
+- [How do I get in touch with you?](#how-do-i-get-in-touch-with-you)
+
+## What is the status of this archive?
+The NNJA-AI archive is currently a preview release; once we have updated the archive with all datasets and received user feedback,
+we will release a stable version with datasets backfill to match the data available in the original NNJA archive.
+
+## What datasets do you have?
+All datasets currently available are listed in the [datasets documentation](/docs/datasets.md).
+We are working to add more datasets to the archive, and will update the documentation as we add more datasets.
+
+## What format is the data in and where is it stored?
+The data is stored on GCS in parquets with partitions for each day.
+See the example notebook [here](/example_notebooks/basic_dataset_example.ipynb) for a guide on how to access the data.
+
+## Why is are some columns still a structured field?
+The original BUFR data is highly structured, with multiple levels of nested data.
+While we have flattened the data as much as possible, there are some cases where the data is still structured.
+This is either because the original data could not be flattened
+(this is the case for fields which are variable-length lists, such as the upper air significant level data),
+or because the data is not worth flattening (e.g. because all subcolumns are null-valued).
+
+## Why didn't you use zarr instead of parquet?
+We considered using zarr as the underlying storage format, but decided to use parquet for a few reasons:
+- The original BUFR data is inherently tabular, and parquet is a good format for tabular data.
+- Generally the data is one-dimensional (time), and zarr's strength is in multi-dimensional data.
+There are some datasets that have some additional dimensions (e.g. channel for satellite data),
+but we decided to stick with one format for simplicity.
+- There are many tools and libraries that support parquet (e.g. pandas, polars, dask, BigQuery, etc.)
+
+## There are too many columns! How do I filter them?
+We have classified the columns into the following categories, based on our understanding of the data:
+`primary data`, `primary descriptors`, `secondary data`, `secondary descriptors`.
+You can quickly filter the columns with a snippet like the following:
+```
+dataset = catalog[DATASET_NAME]
+primary_vars = [k for k,v in dataset.variables.items() if v.category in ['primary data','primary descriptors']]
+dataset = dataset.sel(variables=primary_vars)
+```
+
+## What are code and flag table variables?
+Some variables are encoded as a code table or flag table.
+We're working on adding a helper utility to incorporate these into the archive and decode them,
+but in the meantime you can use the `extra_metadata` to view the code table or flag table to link to the NOAA code table page.
+
+```python
+catalog = DataCatalog(json_uri="gs://nnja-ai/data/v1-preview/catalog.json", skip_manifest=True)  # skip_manifest=True avoids scanning GCS for dataset contents, just a bit faster
+ds = catalog['seviri-sevasr-NC021042']
+ds.variables['SIDENSEQ.SIDGRSEQ.SAID'].extra_metadata
+```
+
+```console
+{'units': 'Code table',
+ 'code table': '001007',
+ 'code table link': 'https://www.nco.ncep.noaa.gov/sib/jeff/CodeFlag_0_STDv31_LOC7.html#001007'}
+```
+
+
+## Why is this entire column missing data?
+We included all data fields from the original BUFR data.
+Some data fields were not populated in the original data (e.g. GOES warm channels are not present in the ABI data).
+If the [datasets documentation](/docs/datasets.md) does not mention a missing field that you think should be present,
+please raise an issue on [GitHub](https://github.com/brightbandtech/nnja-ai/issues)
+and we will check with the data providers and update the documentation (or if you check, please let us know!).
+
+## Will you keep the datasets current with the most recent data?
+
+The original NNJA archive is updated periodically. After we finalize a stable version of the AI archive,
+we aim to maintain the archive up to date with the most recent data, schedule to be determined.
+
+## How do I get in touch with you?
+
+Feel free to raise an issue on [GitHub](https://github.com/brightbandtech/nnja-ai/issues)
+or contact us at [hello@brightband.com](mailto:hello@brightband.com) with questions, suggestions, or feedback.


### PR DESCRIPTION
This commit adds comprehensive documentation for several satellite radiance datasets in the datasets.md file, including:
- Himawari Advanced Himawari Imager (AHI) Clear-Sky Radiance
- GOES All-Sky Radiances
- GOES Clear-Sky Radiances
- SEVIRI All-Sky Radiances

Additionally, a new FAQ.md file is created to provide detailed information about the project, data format, and usage guidelines.