### PR TITLE
Change to dimension format string spec, minor updates to documentation. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+### Added
+- Documentation for the following datasets: ADPSFC, geostationary satellites
+- Created FAQ page and understanding-the-data for more details
+- Support for anonymous credentials in GCS access
+
+### Changed
+- Updated backend_kwargs handling in pandas load_dataset
+- Relaxed Python version requirements (from 3.12+ to 3.10+)
+- Tweaked how format strings for dimensions are parsed (using .format() instead of more restrictive f-string formatting). This is a breaking change since we are updating the dataset jsons to match the new format.
+
+### Fixed
+- Corrected variable naming from `engine` to `backend` in example notebook
+
+
 ## [0.1.0] - 2024-11-01
 ### Added
 - Initial release of the `nnja` Python SDK.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This is the companion Python SDK to the [Brightband](https://www.brightband.com/) AI-ready reprocessing of the [NOAA NASA Joint Archive](https://psl.noaa.gov/data/nnja_obs/) (NNJA).
 It is meant to serve as a helpful interface between a user and the underlying NNJA datasets (which currently consist of parquet files on [GCS](https://console.cloud.google.com/storage/browser/nnja-ai)).
 
+> ⚠️ **Beta Status Warning**: This package is currently in beta (pre-1.0.0). Breaking changes may occur between releases. Users are advised to install directly from the main branch to ensure they have the latest version with all fixes and improvements.
+
+
 ## Background
 The NNJA archive project is a curated archive of Earth system data from 1979 to present.
 This data represents a rich trove of observational data for use in AI weather modelling, however the archival format in which the data is originally available (BUFR) is cumbersome to work with.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -21,6 +21,13 @@ We are working to add more datasets to the archive, and will update the document
 ## What format is the data in and where is it stored?
 The data is stored on GCS in parquets with partitions for each day.
 See the example notebook [here](/example_notebooks/basic_dataset_example.ipynb) for a guide on how to access the data.
+If you prefer to bypass this SDK, you can currently find the v1-preview datasets here:
+`gs://nnja-ai/data/v1-preview/` for direct access to the parquet files.
+
+## What have you done to process the NNJA BUFR files?
+1) convert from BUFR to AVRO, preserving all the structure of the original BUFR messages (nested types, etc.).
+2) 'flatten' the complex columns (array, struct) into simple scalar columns.
+3) combined 6-hourly files into daily Parquet partitions based on the observation timestamp.
 
 ## Why is are some columns still a structured field?
 The original BUFR data is highly structured, with multiple levels of nested data.
@@ -65,7 +72,7 @@ ds.variables['SIDENSEQ.SIDGRSEQ.SAID'].extra_metadata
 ```
 
 
-## Why is this entire column missing data?
+## Why is this or that entire column missing data?
 We included all data fields from the original BUFR data.
 Some data fields were not populated in the original data (e.g. GOES warm channels are not present in the ABI data).
 If the [datasets documentation](/docs/datasets.md) does not mention a missing field that you think should be present,

--- a/src/nnja/dataset.py
+++ b/src/nnja/dataset.py
@@ -219,7 +219,7 @@ class NNJADataset:
         variables = {}
         dim_fmt_str = self.dimensions[var_metadata["dimension"]]["format_str"]
         for value in dim_values:
-            formatted_value = f"{value:{dim_fmt_str}}"
+            formatted_value = dim_fmt_str.format(value)
             full_id = f"{var_metadata['id']}_{formatted_value}"
             variables[full_id] = NNJAVariable(var_metadata, full_id)
         return variables

--- a/tests/sample_data/adpsfc_NC000001_dataset.json
+++ b/tests/sample_data/adpsfc_NC000001_dataset.json
@@ -9,7 +9,7 @@
         "channel": {
           "units": null,
           "values": [1, 2, 3, 4, 5],
-          "format_str": "05.0f"
+          "format_str": "{:05.0f}"
         }
       }
     ],

--- a/tests/sample_data/adpsfc_NC000002_dataset.json
+++ b/tests/sample_data/adpsfc_NC000002_dataset.json
@@ -8,7 +8,7 @@
         "channel": {
           "units": null,
           "values": [1, 2, 3, 4, 5],
-          "format_str": "05.0f"
+          "format_str": "{:05.0f}"
         }
       }
     ],

--- a/tests/sample_data/adpsfc_NC000007_dataset.json
+++ b/tests/sample_data/adpsfc_NC000007_dataset.json
@@ -8,7 +8,7 @@
         "channel": {
           "units": null,
           "values": [1, 2, 3, 4, 5],
-          "format_str": "05.0f"
+          "format_str": "{:05.0f}"
         }
       }
     ],

--- a/tests/sample_data/amsu_dataset.json
+++ b/tests/sample_data/amsu_dataset.json
@@ -8,7 +8,7 @@
         "channel": {
           "units": null,
           "values": [1, 2, 3, 4, 5],
-          "format_str": "05.0f"
+          "format_str": "{:05.0f}"
         }
       }
     ],


### PR DESCRIPTION
Main change is the format_str in the dataset dimension representation for additional dimensions (pressure levels, etc). This is used to decode the dimension values to column names in the underlying parquet, but was too restrictive. In particular it didn't allow us to represent the pressure level values which are formatted like XXXX_PRLC200 (the PRLC prefix couldn't be added). 
It's a small change but it does require that we update all the dataset jsons (see how the test jsons are updated to understand exactly why). This means that previous versions of the package won't work anymore for properly decoding the dataset jsons. We're still in beta; once we release a full v1.0.0 (within the next month or so) we'll have a stable API and guarantee backward compatibility. 