### PR TITLE
Improve auth handling

### DIFF
--- a/example_notebooks/basic_dataset_example.ipynb
+++ b/example_notebooks/basic_dataset_example.ipynb
@@ -32,9 +32,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nnja.io import _check_authentication\n",
-    "if _check_authentication():\n",
-    "    from nnja import DataCatalog"
+    "from nnja import DataCatalog"
    ]
   },
   {
@@ -412,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.5"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Previous auth handling basically forced user to anonymous creds, which is fine for end users but isn't sufficiently flexible for data development (we can't get the right creds for accessing our testing bucket). Improved with an optional env variable overriding the default use of anonymous credentials.