### PR TITLE
refactor: Add multi-bucket support with configurable base paths

### DIFF
--- a/src/nnja/dataset.py
+++ b/src/nnja/dataset.py
@@ -30,6 +30,26 @@ DimensionIndexKey = Union[
 logger = logging.getLogger(__name__)
 
 
+def _resolve_path(base_path: str, relative_path: str) -> str:
+    """Resolve a relative path against a base path, or return absolute paths as-is.
+
+    Args:
+        base_path: The base path to resolve against
+        relative_path: The path to resolve (can be absolute or relative)
+
+    Returns:
+        str: The resolved absolute path
+    """
+    # If the path contains a scheme (e.g., gs://, s3://, http://), it's absolute
+    if "://" in relative_path:
+        return relative_path
+
+    # Otherwise, join with base_path
+    base_path = base_path.rstrip("/")
+    relative_path = relative_path.lstrip("/")
+    return f"{base_path}/{relative_path}"
+
+
 class NNJADataset:
     """NNJADataset class for handling dataset metadata and loading data.
 
@@ -55,12 +75,14 @@ class NNJADataset:
             f"description='{self.description[:100]})'"
         )
 
-    def __init__(self, json_uri: str, skip_manifest: bool = False):
+    def __init__(self, json_uri: str, base_path: str = "", skip_manifest: bool = False):
         """
         Initialize an NNJADataset object from a JSON file or URI.
 
         Args:
             json_uri: Path or URI to the dataset's JSON metadata.
+            base_path: Base path for resolving relative parquet_root_path.
+            skip_manifest: Skip loading the manifest for each dataset.
         """
         import nnja.schemas
 
@@ -68,12 +90,16 @@ class NNJADataset:
             "dataset_schema_v1.json"
         )
         self.json_uri = json_uri
+        self.base_path = base_path
         dataset_metadata = io.read_json(json_uri, dataset_schema)
         self.dataset_metadata = dataset_metadata
         self.name: str = dataset_metadata["name"]
         self.description: str = dataset_metadata["description"]
         self.tags: List[str] = dataset_metadata["tags"]
-        self.parquet_root_path: str = dataset_metadata["parquet_root_path"]
+
+        # Resolve parquet_root_path relative to base_path
+        raw_parquet_path = dataset_metadata["parquet_root_path"]
+        self.parquet_root_path: str = _resolve_path(base_path, raw_parquet_path)
         self.manifest: pd.DataFrame = pd.DataFrame()
         if not skip_manifest:
             self.manifest = io.load_manifest(self.parquet_root_path)

--- a/tests/sample_data/adpsfc_NC000001_dataset.json
+++ b/tests/sample_data/adpsfc_NC000001_dataset.json
@@ -2,7 +2,7 @@
     "name": "WMOSYNOP_fixed",
     "description": "Synoptic - fixed land (originating from WMO SYNOP bulletins).",
     "tags": ["surface", "fixed-station", "synoptic", "wmo"],
-    "parquet_root_path": "foo/bar/fake/parquet/root/",
+    "parquet_root_path": "adpsfc/1bamua/NC000001/",
     "time_index": "OBS_DATE",
     "dimensions": [
       {

--- a/tests/sample_data/adpsfc_NC000002_dataset.json
+++ b/tests/sample_data/adpsfc_NC000002_dataset.json
@@ -2,7 +2,7 @@
     "name": "WMOSYNOP_mobile",
     "description": "Synoptic - mobile land (originating from WMO SYNOP bulletins). Mostly India data.",
     "tags": ["surface", "fixed-station", "synoptic", "wmo", "india"],
-    "parquet_root_path": "foo/bar/fake/parquet/root/",
+    "parquet_root_path": "adpsfc/1bamua/NC000002/",
     "dimensions": [
       {
         "channel": {

--- a/tests/sample_data/adpsfc_NC000007_dataset.json
+++ b/tests/sample_data/adpsfc_NC000007_dataset.json
@@ -2,7 +2,7 @@
     "name": "BUFRSYNOP_fixed",
     "description": "The surface data from METAR stations at airports. Mostly US/Europe data.",
     "tags": ["surface", "aviation", "metar", "sfc", "temperature", "precipitation"],
-    "parquet_root_path": "foo/bar/fake/parquet/root/",
+    "parquet_root_path": "adpsfc/1bamua/NC000007/",
     "dimensions": [
       {
         "channel": {

--- a/tests/sample_data/amsu_dataset.json
+++ b/tests/sample_data/amsu_dataset.json
@@ -2,7 +2,7 @@
     "name": "amsu_sample_data",
     "description": "Sample AMSU dataset with temperature brightness values and geospatial metadata.",
     "tags": ["amsu", "sample", "brightness_temperature", "geospatial"],
-    "parquet_root_path": "foo/bar/fake/parquet/root/",
+    "parquet_root_path": "amsu/1bamua/MSGTYPE_1/",
     "dimensions": [
       {
         "channel": {

--- a/tests/sample_data/catalog.json
+++ b/tests/sample_data/catalog.json
@@ -6,7 +6,7 @@
           "name": "amsu_sample_data",
           "description": "Sample AMSU dataset with temperature brightness values and geospatial metadata.",
           "tags": ["amsu", "sample", "brightness_temperature", "geospatial"],
-          "json": "tests/sample_data/amsu_dataset.json"
+          "json": "amsu_dataset.json"
         }
       }
     },
@@ -17,19 +17,19 @@
           "name": "WMOSYNOP_fixed",
           "description": "Synoptic - fixed land (originating from WMO SYNOP bulletins).",
           "tags": ["surface", "fixed-station", "synoptic", "wmo"],
-          "json": "tests/sample_data/adpsfc_NC000001_dataset.json"
+          "json": "adpsfc_NC000001_dataset.json"
         },
         "NC000002": {
           "name": "WMOSYNOP_mobile",
           "description": "Synoptic - mobile land (originating from WMO SYNOP bulletins). Mostly India data.",
           "tags": ["surface", "fixed-station", "synoptic", "wmo", "india"],
-          "json": "tests/sample_data/adpsfc_NC000002_dataset.json"
+          "json": "adpsfc_NC000002_dataset.json"
         },
         "NC000007": {
           "name": "BUFRSYNOP_fixed",
           "description": "The surface data from METAR stations at airports. Mostly US/Europe data.",
           "tags": ["surface", "aviation", "metar", "sfc", "temperature", "precipitation"],
-          "json": "tests/sample_data/adpsfc_NC000007_dataset.json"
+          "json": "adpsfc_NC000007_dataset.json"
         }
       }
     }

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -97,13 +97,15 @@ def sample_dataset(tmp_path):
     with open(tmp_path / "test_dataset.json", "w") as f:
         json.dump(metadata, f)
 
-    dataset = NNJADataset(str(tmp_path / "test_dataset.json"))
+    dataset = NNJADataset(str(tmp_path / "test_dataset.json"), base_path=str(tmp_path))
     return dataset
 
 
 def test_dataset_initialization():
     dataset = NNJADataset(
-        "tests/sample_data/adpsfc_NC000001_dataset.json", skip_manifest=True
+        "tests/sample_data/adpsfc_NC000001_dataset.json",
+        base_path="tests/sample_data",
+        skip_manifest=True,
     )
     assert dataset.name == "WMOSYNOP_fixed"
     assert dataset.tags == ["surface", "fixed-station", "synoptic", "wmo"]
@@ -112,7 +114,11 @@ def test_dataset_initialization():
 
 
 def test_variable_expansion():
-    dataset = NNJADataset("tests/sample_data/amsu_dataset.json", skip_manifest=True)
+    dataset = NNJADataset(
+        "tests/sample_data/amsu_dataset.json",
+        base_path="tests/sample_data",
+        skip_manifest=True,
+    )
     variables = dataset.variables
     channels = [1, 2, 3, 4, 5]
     expected_variables = ["lat", "lon", "time", "said", "fovn"]
@@ -123,7 +129,11 @@ def test_variable_expansion():
 
 
 def test_get_variable():
-    dataset = NNJADataset("tests/sample_data/amsu_dataset.json", skip_manifest=True)
+    dataset = NNJADataset(
+        "tests/sample_data/amsu_dataset.json",
+        base_path="tests/sample_data",
+        skip_manifest=True,
+    )
     variable = dataset["lat"]
     assert variable.id == "lat"
     assert variable.description == "Latitude of the observation."

--- a/uv.lock
+++ b/uv.lock
@@ -1749,7 +1749,7 @@ wheels = [
 
 [[package]]
 name = "nnja"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "fsspec" },


### PR DESCRIPTION
## Summary
**Breaking Change**: Refactors catalog configuration to support data mirroring across multiple cloud buckets and storage locations using relative paths + configurable base paths. This enables organizations to maintain data copies in different clouds or local storage without requiring separate catalog files.

## Changes
- **Breaking**: `DataCatalog` constructor now uses `mirror` parameter instead of `json_uri`
- Added predefined mirror configurations: `gcp_brightband`, `gcp_nodd`. `aws_opendata` to be added later on.
- Updated catalog and dataset JSONs to use relative paths, making them portable across storage backends
- Added path resolution logic that handles both absolute and relative URIs
- `NNJADataset` now accepts `base_path` parameter for resolving relative parquet paths

## Usage
**Predefined mirrors:**
```python
catalog = DataCatalog(mirror="gcp_nodd")  # Default
catalog = DataCatalog(mirror="gcp_brightband")
```

**Custom configuration:**
```python
catalog = DataCatalog(
    mirror=None,
    base_path="gs://my-bucket/data", 
    catalog_json="catalog.json"
)
```

## Benefits
- **Multi-cloud portability**: Same catalog files work across different storage backends
- **Local development**: Easy to point to local data copies 
- **Clean separation**: "Where is data" (base_path) vs "What data exists" (catalog structure)

Closes #44

**Note**: This refactor significantly simplifies the workflow for users who download NNJA data locally (addresses #40). Previously, users had to manually modify catalog and dataset JSON files with absolute paths when pointing to local data. Now, users can reuse the same catalog files unchanged by simply specifying a local `base_path`, making local development and training workflows much more straightforward.