### PR TITLE
Swap `print()` call in `dataset.py` with `logger.info()`

### DIFF
--- a/src/nnja_ai/dataset.py
+++ b/src/nnja_ai/dataset.py
@@ -99,7 +99,7 @@ class NNJADataset:
     def manifest(self) -> pd.DataFrame:
         """Get the dataset's manifest of parquet partitions, loading it if needed."""
         if not self._manifest_loaded:
-            print(f"Loading manifest for dataset '{self.name}'...")
+            logger.info(f"Loading manifest for dataset '{self.name}'...")
             self._manifest_cache = io.load_manifest(self.parquet_root_path)
             self._manifest_loaded = True
         return self._manifest_cache


### PR DESCRIPTION
Hi folks! First off, many thanks for this amazing resource. I have created a workflow for comparing forecast models directly against observations, and I've found the nnja-ai datasets and API to be incredibly useful. Hats off to you all 👏

This PR is just a micro suggestion, so let me know what you think. Right now, every time a dataset gets loaded we get a print statement like:

```
Loading manifest for dataset '{self.name}'
```

Is there any reason this is a print statement? When I run this for example using SLURM, it results in these print statements coming at the end of the job and in a different location from the rest of the nnja_ai logging, since they're not piped in the same way as the logger. Because of that, the statements are not really useful progress markers. I think it would be nice to get these with the rest of the logs, hence the PR.

Let me know what you think! Thanks again for this awesome package!